### PR TITLE
Ignore changes to the lambda package

### DIFF
--- a/BD.md
+++ b/BD.md
@@ -1,0 +1,37 @@
+# Changes made for Brad's Deals
+
+Changes made to the fork:
+  - Ignores all lambda packages changes and the version tag since we update via GHAs rather than through terraform.
+
+## Updating
+
+If cloning through the `gh` cli, it will automatically setup an `upstream` remote.  Otherwise, one will need to add the upstream remote:
+
+```bash
+git remote add upstream https://github.com/terraform-aws-modules/terraform-aws-lambda.git
+```
+
+Sync the master branch to our `bd` branch.  Note that this can be done through the UI with the "Sync fork" button.  Otherwise, via command line:
+
+<!-- TODO: Does the sync rebase or merge? -->
+```bash
+```
+
+Pull the latest tag and push up to our fork:
+
+```bash
+git pull upstream $RELEASE_TAG
+git push origin $RELEASE_TAG
+```
+
+Checkout onto the tag that we are upgrading, checkout to a new branch, merge in the `bd` branch, and push a new tag:
+
+```bash
+git checkout $RELEASE_TAG
+git checkout -b bd-release/$RELEASE_TAG
+git pull --no-rebase origin bd
+git tag $RELEASE_TAG-bd
+git push origin $RELEASE_TAG-bd
+```
+
+Optional: Cut a new release from the tag.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # AWS Lambda Terraform module
 
+Changes made to the fork:
+  - Ignores all lambda packages changes and the version tag since we update via GHAs rather than through terraform.
+
 Terraform module, which creates almost all supported AWS Lambda resources as well as taking care of building and packaging of required Lambda dependencies for functions and layers.
 
 [![SWUbanner](https://raw.githubusercontent.com/vshymanskyy/StandWithUkraine/main/banner2-direct.svg)](https://github.com/vshymanskyy/StandWithUkraine/blob/main/docs/README.md)

--- a/README.md
+++ b/README.md
@@ -1,8 +1,5 @@
 # AWS Lambda Terraform module
 
-Changes made to the fork:
-  - Ignores all lambda packages changes and the version tag since we update via GHAs rather than through terraform.
-
 Terraform module, which creates almost all supported AWS Lambda resources as well as taking care of building and packaging of required Lambda dependencies for functions and layers.
 
 [![SWUbanner](https://raw.githubusercontent.com/vshymanskyy/StandWithUkraine/main/banner2-direct.svg)](https://github.com/vshymanskyy/StandWithUkraine/blob/main/docs/README.md)

--- a/main.tf
+++ b/main.tf
@@ -165,6 +165,19 @@ resource "aws_lambda_function" "this" {
     aws_iam_role_policy_attachment.additional_many,
     aws_iam_role_policy_attachment.additional_one,
   ]
+
+  lifecycle {
+    ignore_changes = [
+      # Ignore all changes to the package itself as we will deploy this with a different process.
+      source_code_hash,
+      filename,
+      s3_bucket,
+      s3_key,
+      s3_object_version,
+      # The version tag changes as the package changes and we do not want to delete it when making changes to the lambda.
+      tags["version"],
+    ]
+  }
 }
 
 resource "aws_lambda_layer_version" "this" {


### PR DESCRIPTION
## Problem

<!-- What are you trying to solve? -->

We would like to use the community module, but ignore changes to the lambda package since we update this via another method outside of terraform.

## Solution

<!-- How does this change fix the problem? -->

* Ignores all changes to the lambda package and the "version" tag.
* Adds notes for syncing the fork, merging in the custom changes, and pushing up a new tag.

## Notes

<!-- Additional notes here -->

